### PR TITLE
Implement basic text error reporter

### DIFF
--- a/libylang/parsing/Location.h
+++ b/libylang/parsing/Location.h
@@ -1,3 +1,5 @@
+#pragma once
+
 #include "parsing/Manager.h"
 #include <cstddef>
 #include <memory>

--- a/libylang/report/CMakeLists.txt
+++ b/libylang/report/CMakeLists.txt
@@ -1,6 +1,10 @@
-set(LOCAL_SOURCES 
-  Cache.h 
+set(LOCAL_SOURCES
+  Cache.h
   Cache.cc
+  Diagnostic.h
+  Diagnostic.cc
+  Reporter.h
+  Reporter.cc
 )
 
 set(LOCAL_SOURCES_WITH_PATH)

--- a/libylang/report/Diagnostic.cc
+++ b/libylang/report/Diagnostic.cc
@@ -1,0 +1,8 @@
+#include <report/Diagnostic.h>
+
+namespace ylang::report {
+
+BasicDiagnostic::BasicDiagnostic(Severity sev, std::string msg, parsing::Location loc)
+    : sev_(sev), msg_(std::move(msg)), loc_(std::move(loc)) {}
+
+} // namespace ylang::report

--- a/libylang/report/Diagnostic.h
+++ b/libylang/report/Diagnostic.h
@@ -1,0 +1,33 @@
+#pragma once
+
+#include "parsing/Location.h"
+#include <string>
+#include <string_view>
+
+namespace ylang::report {
+
+enum class Severity { Note, Warning, Error };
+
+class Diagnostic {
+public:
+  virtual ~Diagnostic() = default;
+  virtual Severity severity() const = 0;
+  virtual std::string_view message() const = 0;
+  virtual parsing::Location location() const = 0;
+};
+
+class BasicDiagnostic : public Diagnostic {
+private:
+  Severity sev_;
+  std::string msg_;
+  parsing::Location loc_;
+
+public:
+  BasicDiagnostic(Severity sev, std::string msg, parsing::Location loc);
+
+  Severity severity() const override { return sev_; }
+  std::string_view message() const override { return msg_; }
+  parsing::Location location() const override { return loc_; }
+};
+
+} // namespace ylang::report

--- a/libylang/report/Reporter.cc
+++ b/libylang/report/Reporter.cc
@@ -1,0 +1,53 @@
+#include <iomanip>
+#include <iostream>
+#include <report/Reporter.h>
+
+namespace ylang::report {
+
+static const char *severityToString(Severity s) {
+  switch (s) {
+  case Severity::Note:
+    return "note";
+  case Severity::Warning:
+    return "warning";
+  case Severity::Error:
+    return "error";
+  }
+  return "";
+}
+
+TextReporter::TextReporter(ReportCache &cache, std::ostream &os)
+    : cache_(cache), os_(os) {}
+
+void TextReporter::report(const Diagnostic &diag) {
+  os_ << severityToString(diag.severity()) << ": " << diag.message() << '\n';
+  auto loc = diag.location();
+  if (!loc.file) {
+    return;
+  }
+  auto srcOpt = cache_.getSource(loc.file->filename);
+  if (!srcOpt) {
+    os_ << " -> " << loc.file->filename << ':' << loc.start + 1 << '\n';
+    return;
+  }
+  const auto &srcCache = srcOpt->get();
+  auto lineOpt = srcCache.getLine(loc.start);
+  if (!lineOpt) {
+    os_ << " -> " << loc.file->filename << ':' << loc.start + 1 << '\n';
+    return;
+  }
+  const Line &line = lineOpt->get();
+  std::string_view lineView(loc.file->content.data() + line.start,
+                            line.stop - line.start);
+  std::size_t colStart = loc.start - line.start;
+  std::size_t colEnd = loc.stop - line.start;
+  os_ << " --> " << loc.file->filename << ':' << line.line << ':' << colStart + 1
+      << '\n';
+  std::string lineNumStr = std::to_string(line.line);
+  os_ << lineNumStr << " | " << lineView << '\n';
+  os_ << std::string(lineNumStr.size(), ' ') << " | "
+      << std::string(colStart, ' ')
+      << std::string(std::max<std::size_t>(1, colEnd - colStart), '^') << '\n';
+}
+
+} // namespace ylang::report

--- a/libylang/report/Reporter.h
+++ b/libylang/report/Reporter.h
@@ -1,0 +1,27 @@
+#pragma once
+
+#include "Cache.h"
+#include "Diagnostic.h"
+#include <iosfwd>
+#include <iostream>
+
+namespace ylang::report {
+
+class Reporter {
+public:
+  virtual ~Reporter() = default;
+  virtual void report(const Diagnostic &diag) = 0;
+};
+
+class TextReporter : public Reporter {
+private:
+  ReportCache &cache_;
+  std::ostream &os_;
+
+public:
+  TextReporter(ReportCache &cache, std::ostream &os = std::cerr);
+
+  void report(const Diagnostic &diag) override;
+};
+
+} // namespace ylang::report


### PR DESCRIPTION
## Summary
- add `Diagnostic` abstraction to describe messages
- implement `TextReporter` for simple GCC-style diagnostics
- cache sources with `ReportCache`
- showcase reporter usage in `yc/main.cc`
- fix missing include guard in `Location.h`

## Testing
- `cmake ..`
- `cmake --build .`
- `./bin/yc`

------
https://chatgpt.com/codex/tasks/task_e_68540b491adc8333bc1feacd05cb7021