### PR TITLE
Simplify report system

### DIFF
--- a/libsable/report/CMakeLists.txt
+++ b/libsable/report/CMakeLists.txt
@@ -1,10 +1,15 @@
-set(LOCAL_SOURCES  
+set(LOCAL_SOURCES
   Diagnostic.h
+  Diagnostic.cc
   Engine.h
+  Engine.cc
   Span.h
+  Span.cc
   Label.h
+  Label.cc
   Write.h
-  Cache.h 
+  Write.cc
+  Cache.h
   Cache.cc
 )
 

--- a/libsable/report/Cache.cc
+++ b/libsable/report/Cache.cc
@@ -54,14 +54,13 @@ std::span<const Line> CacheEntry::getLines(common::Range<std::size_t> range) con
 
 Cache::Cache(const common::Manager &manager) : manager(manager) {}
 
-void Cache::addEntry(const Span &span) {
-  auto it = entries.find(span.source());
+void Cache::addEntry(std::shared_ptr<common::Source> source) {
+  if (!source) {
+    return;
+  }
+  auto it = entries.find(source->filename);
   if (it == entries.end()) {
-    std::shared_ptr<common::Source> source =
-        manager.getContent(span.source()).value_or(nullptr);
-    if (source) {
-      entries.emplace(span.source(), CacheEntry(source));
-    }
+    entries.emplace(source->filename, CacheEntry(std::move(source)));
   }
 }
 

--- a/libsable/report/Cache.cc
+++ b/libsable/report/Cache.cc
@@ -55,18 +55,18 @@ std::span<const Line> CacheEntry::getLines(common::Range<std::size_t> range) con
 Cache::Cache(const common::Manager &manager) : manager(manager) {}
 
 void Cache::addEntry(const Span &span) {
-  auto it = entries.find(span);
+  auto it = entries.find(span.source());
   if (it == entries.end()) {
     std::shared_ptr<common::Source> source =
         manager.getContent(span.source()).value_or(nullptr);
     if (source) {
-      entries.emplace(span, CacheEntry(source));
+      entries.emplace(span.source(), CacheEntry(source));
     }
   }
 }
 
 std::optional<const CacheEntry *> Cache::getEntry(const Span &span) const {
-  auto it = entries.find(span);
+  auto it = entries.find(span.source());
   if (it != entries.end()) {
     return &it->second;
   }

--- a/libsable/report/Cache.h
+++ b/libsable/report/Cache.h
@@ -41,7 +41,7 @@ private:
 public:
   explicit Cache(const common::Manager &manager);
 
-  void addEntry(const Span &span);
+  void addEntry(std::shared_ptr<common::Source> source);
   std::optional<const CacheEntry *> getEntry(const Span &span) const;
 
   const common::Manager &getManager() const;

--- a/libsable/report/Cache.h
+++ b/libsable/report/Cache.h
@@ -8,6 +8,7 @@
 #include <optional>
 #include <span>
 #include <unordered_map>
+#include <string_view>
 #include <vector>
 
 namespace sable::report {
@@ -35,7 +36,7 @@ struct CacheEntry {
 class Cache {
 private:
   const common::Manager &manager;
-  std::unordered_map<Span, CacheEntry> entries;
+  std::unordered_map<std::string_view, CacheEntry> entries;
 
 public:
   explicit Cache(const common::Manager &manager);

--- a/libsable/report/Diagnostic.cc
+++ b/libsable/report/Diagnostic.cc
@@ -1,0 +1,48 @@
+#include "report/Diagnostic.h"
+
+namespace sable::report {
+
+std::ostream &operator<<(std::ostream &os, Severity severity) {
+  switch (severity) {
+#define X(name, color) case Severity::name: os << color << #name << ANSI_RESET; break;
+    SEVERITY_LEVELS
+#undef X
+  default:
+    os << "Unknown";
+    break;
+  }
+  return os;
+}
+
+Diagnostic::Diagnostic(Severity severity) : severity(severity) {}
+
+Diagnostic &Diagnostic::withMessage(const std::string &msg) {
+  message = msg;
+  return *this;
+}
+
+Diagnostic &Diagnostic::withCode(const Span &span) {
+  code = span;
+  return *this;
+}
+
+Diagnostic &Diagnostic::withLabel(const Label &label) {
+  labels.push_back(label);
+  return *this;
+}
+
+std::ostream &Diagnostic::print(std::ostream &os, const Cache &cache) const {
+  os << severity << ": ";
+  if (message) {
+    os << *message;
+  }
+  os << "\n";
+
+  if (code) {
+    SpanWrite::write(os, *code, cache);
+  }
+
+  return os;
+}
+
+} // namespace sable::report

--- a/libsable/report/Diagnostic.h
+++ b/libsable/report/Diagnostic.h
@@ -17,9 +17,9 @@
 
 namespace sable::report {
 
-#define SEVERITY_LEVELS                                                        \
-  X(Info, ANSI_BLUE)                                                           \
-  X(Warning, ANSI_YELLOW)                                                      \
+#define SEVERITY_LEVELS \
+  X(Info, ANSI_BLUE) \
+  X(Warning, ANSI_YELLOW) \
   X(Error, ANSI_RED)
 
 enum class Severity {
@@ -28,60 +28,23 @@ enum class Severity {
 #undef X
 };
 
-inline std::ostream &operator<<(std::ostream &os, Severity severity) {
-  switch (severity) {
-#define X(name, color)                                                         \
-  case Severity::name:                                                         \
-    os << color << #name << ANSI_RESET;                                        \
-    break;
-    SEVERITY_LEVELS
-#undef X
-  default:
-    os << "Unknown";
-    break;
-  }
-  return os;
-}
+std::ostream &operator<<(std::ostream &os, Severity severity);
 
-template <typename S> class Diagnostic {
-  static_assert(is_derived_from_span_v<S>,
-                "S must be derived from Span<T> for some type T");
-
+class Diagnostic {
 private:
   Severity severity;
   std::optional<std::string> message;
-  std::optional<S> code;
-  std::vector<Label<S>> labels;
+  std::optional<Span> code;
+  std::vector<Label> labels;
 
 public:
-  Diagnostic(Severity severity) : severity(severity) {}
+  explicit Diagnostic(Severity severity);
 
-  inline Diagnostic<S> &withMessage(const std::string &msg) {
-    message = msg;
-    return *this;
-  }
-  inline Diagnostic<S> &withCode(const S &span) {
-    code = span;
-    return *this;
-  }
-  inline Diagnostic<S> &withLabel(const Label<S> &label) {
-    labels.push_back(label);
-    return *this;
-  }
+  Diagnostic &withMessage(const std::string &msg);
+  Diagnostic &withCode(const Span &span);
+  Diagnostic &withLabel(const Label &label);
 
-  std::ostream &print(std::ostream &os, const Cache<S> &cache) const {
-    os << severity << ": ";
-    if (message) {
-      os << *message;
-    }
-    os << "\n";
-
-    if (code) {
-      SpanWrite<S>::write(os, *code, cache);
-    }
-
-    return os;
-  }
+  std::ostream &print(std::ostream &os, const Cache &cache) const;
 };
 
 } // namespace sable::report

--- a/libsable/report/Engine.cc
+++ b/libsable/report/Engine.cc
@@ -1,0 +1,13 @@
+#include "report/Engine.h"
+
+namespace sable::report {
+
+StreamWriter::StreamWriter(std::ostream &output_stream, const Cache &manager)
+    : os(output_stream), cache(manager) {}
+
+void StreamWriter::report(const Diagnostic &diag) {
+  diag.print(os, cache);
+  os << std::endl;
+}
+
+} // namespace sable::report

--- a/libsable/report/Engine.h
+++ b/libsable/report/Engine.h
@@ -2,30 +2,25 @@
 
 #include "report/Cache.h"
 #include "report/Diagnostic.h"
-#include <iostream>
 #include <ostream>
 
 namespace sable::report {
-template <typename S> class DiagnosticEngine {
+
+class DiagnosticEngine {
 public:
   virtual ~DiagnosticEngine() = default;
-
-  virtual void report(const Diagnostic<S> &diag) = 0;
+  virtual void report(const Diagnostic &diag) = 0;
 };
 
-template <typename S> class StreamWriter : public DiagnosticEngine<S> {
+class StreamWriter : public DiagnosticEngine {
 private:
   std::ostream &os;
-  const Cache<S> &cache;
+  const Cache &cache;
 
 public:
-  explicit StreamWriter(std::ostream &output_stream, const Cache<S> &manager)
-      : os(output_stream), cache(manager) {}
+  StreamWriter(std::ostream &output_stream, const Cache &manager);
 
-  void report(const Diagnostic<S> &diag) override {
-    diag.print(os, cache);
-    os << std::endl;
-  }
+  void report(const Diagnostic &diag) override;
 };
 
 } // namespace sable::report

--- a/libsable/report/Label.cc
+++ b/libsable/report/Label.cc
@@ -1,0 +1,35 @@
+#include "report/Label.h"
+
+namespace sable::report {
+
+Label::Label(Span span) : span(std::move(span)) {}
+
+Label &Label::withMessage(const std::string &msg) {
+  message = msg;
+  return *this;
+}
+
+std::ostream &Label::print(std::ostream &os, const common::Manager &manager) const {
+  os << span.source() << ":" << span.start() << ":" << span.end();
+  if (message) {
+    os << " --> " << *message;
+  }
+  if (span.length() > 0) {
+    auto file = manager.getContent(span.source());
+    if (file) {
+      os << " | " << file.value()->content.substr(span.start(), span.length());
+    } else {
+      os << " | <unknown content>";
+    }
+  }
+  os << "\n";
+  os << "  " << std::string(span.start(), ' ') << "^";
+  if (span.length() > 1) {
+    os << std::string(span.length() - 1, '~');
+  }
+  os << "\n";
+
+  return os;
+}
+
+} // namespace sable::report

--- a/libsable/report/Label.h
+++ b/libsable/report/Label.h
@@ -7,43 +7,17 @@
 #include <string>
 
 namespace sable::report {
-template <typename S> class Label {
-  static_assert(is_derived_from_span_v<S>,
-                "S must be derived from Span<T> for some type T");
 
+class Label {
 private:
-  S span;
+  Span span;
   std::optional<std::string> message;
 
 public:
-  Label(S span) : span(std::move(span)) {}
+  explicit Label(Span span);
 
-  inline Label<S> &withMessage(const std::string &msg) {
-    message = msg;
-    return *this;
-  }
-
-  std::ostream &print(std::ostream &os, const common::Manager &manager) const {
-    os << span.source() << ":" << span.start() << ":" << span.end();
-    if (message) {
-      os << " --> " << *message;
-    }
-    if (span.length() > 0) {
-      auto file = manager.getContent(span.source());
-      if (file) {
-        os << " | " << file->content.substr(span.start(), span.length());
-      } else {
-        os << " | <unknown content>";
-      }
-    }
-    os << "\n";
-    os << "  " << std::string(span.start(), ' ') << "^";
-    if (span.length() > 1) {
-      os << std::string(span.length() - 1, '~');
-    }
-    os << "\n";
-
-    return os;
-  }
+  Label &withMessage(const std::string &msg);
+  std::ostream &print(std::ostream &os, const common::Manager &manager) const;
 };
+
 } // namespace sable::report

--- a/libsable/report/Span.cc
+++ b/libsable/report/Span.cc
@@ -1,0 +1,27 @@
+#include "report/Span.h"
+
+namespace sable::report {
+
+Span::Span(std::string_view source, common::Range<std::size_t> range)
+    : source_(source), range_(range) {}
+
+const std::string_view &Span::source() const { return source_; }
+std::size_t Span::start() const { return range_.getStart(); }
+std::size_t Span::end() const { return range_.getStop(); }
+std::size_t Span::length() const { return range_.getLength(); }
+common::Range<std::size_t> Span::getRange() const { return range_; }
+
+bool Span::operator==(const Span &other) const {
+  return source_ == other.source_ &&
+         range_.getStart() == other.range_.getStart() &&
+         range_.getStop() == other.range_.getStop();
+}
+
+} // namespace sable::report
+
+size_t std::hash<sable::report::Span>::operator()(const sable::report::Span &span) const {
+  size_t h1 = std::hash<std::string_view>()(span.source());
+  size_t h2 = std::hash<std::size_t>()(span.start());
+  size_t h3 = std::hash<std::size_t>()(span.end());
+  return h1 ^ (h2 << 1) ^ (h3 << 2);
+}

--- a/libsable/report/Span.h
+++ b/libsable/report/Span.h
@@ -2,87 +2,32 @@
 
 #include "common/Range.h"
 #include <cstddef>
-#include <functional>
 #include <string_view>
-#include <type_traits>
-#include <utility>
+#include <functional>
 
 namespace sable::report {
 
-template <typename S> class Span {
-  static_assert(std::is_copy_constructible_v<S>,
-                "T must be copy constructible");
-  static_assert(std::is_copy_assignable_v<S>, "T must be copy assignable");
-  static_assert(std::is_default_constructible_v<std::hash<S>>,
-                "std::hash<T> must be defined");
-  static_assert(std::is_invocable_r_v<std::size_t, std::hash<S>, S>,
-                "std::hash<T> must be callable");
-  static_assert(std::is_convertible_v<
-                    decltype(std::declval<S>() == std::declval<S>()), bool>,
-                "T must support operator==");
-
-public:
-  virtual ~Span() = default;
-
-  virtual const S &source() const = 0;
-  virtual std::size_t start() const = 0;
-  virtual std::size_t end() const = 0;
-  virtual std::size_t length() const { return end() - start(); }
-};
-
-template <typename T> struct is_derived_from_span {
-private:
-  template <typename U> static auto test(const Span<U> *) -> std::true_type;
-  static auto test(...) -> std::false_type;
-
-public:
-  static constexpr bool value = decltype(test(std::declval<T *>()))::value;
-};
-
-template <typename T>
-inline constexpr bool is_derived_from_span_v = is_derived_from_span<T>::value;
-
-template <typename T> struct span_template_argument {
-private:
-  template <typename S> static S test(const sable::report::Span<S> *);
-
-  static void test(...);
-
-public:
-  using type = decltype(test(std::declval<T *>()));
-};
-
-template <typename T>
-using span_template_argument_t = typename span_template_argument<T>::type;
-
-class FileLocSpan : public Span<std::string_view> {
+class Span {
 private:
   std::string_view source_;
-  common::Range<std::size_t> range;
+  common::Range<std::size_t> range_;
 
 public:
-  FileLocSpan(std::string_view source, common::Range<std::size_t> range)
-      : source_(std::move(source)), range(range) {}
+  Span(std::string_view source, common::Range<std::size_t> range);
 
-  const std::string_view &source() const override { return source_; }
-  common::Range<std::size_t> getRange() const { return range; }
+  const std::string_view &source() const;
+  std::size_t start() const;
+  std::size_t end() const;
+  std::size_t length() const;
+  common::Range<std::size_t> getRange() const;
 
-  bool operator==(const FileLocSpan &other) const {
-    return source_ == other.source_ &&
-           range.getStart() == other.range.getStart() &&
-           range.getStop() == other.range.getStop();
-  }
+  bool operator==(const Span &other) const;
 };
 
 } // namespace sable::report
 
 namespace std {
-template <> struct hash<sable::report::FileLocSpan> {
-  std::size_t operator()(const sable::report::FileLocSpan &span) const {
-    std::size_t h1 = std::hash<std::string_view>()(span.source());
-    std::size_t h2 = std::hash<std::size_t>()(span.start());
-    std::size_t h3 = std::hash<std::size_t>()(span.end());
-    return h1 ^ (h2 << 1) ^ (h3 << 2); // Combine the hashes
-  }
+template <> struct hash<sable::report::Span> {
+  size_t operator()(const sable::report::Span &span) const;
 };
 } // namespace std

--- a/libsable/report/Write.cc
+++ b/libsable/report/Write.cc
@@ -1,0 +1,36 @@
+#include "report/Write.h"
+
+namespace sable::report {
+
+void writeLine(std::ostream &os, const Line &line,
+               std::shared_ptr<common::Source> source) {
+  os << line.lineNumber << " | ";
+  os << source->content.substr(line.start(), line.length());
+  os << "\n";
+}
+
+void SpanWrite::write(std::ostream &os, const Span &span, const Cache &cache) {
+  std::optional<const CacheEntry *> entry = cache.getEntry(span);
+
+  if (!entry.has_value()) {
+    return;
+  }
+
+  std::span<const Line> lines =
+      entry.value()->getLines(span.getRange());
+  if (lines.empty())
+    return;
+
+  const Line &line = lines.front();
+  std::size_t line_start = line.start();
+  std::size_t column = span.start() - line_start + 1;
+
+  os << "[" << span.source() << ":" << line.lineNumber << ":" << column
+     << "] ";
+
+  for (const auto &l : lines) {
+    writeLine(os, l, entry.value()->source);
+  }
+}
+
+} // namespace sable::report

--- a/libsable/report/Write.h
+++ b/libsable/report/Write.h
@@ -3,42 +3,17 @@
 #include "common/Manager.h"
 #include "report/Cache.h"
 #include "report/Span.h"
-#include <cstddef>
 #include <memory>
 #include <ostream>
+#include <span>
 
 namespace sable::report {
-static inline void writeLine(std::ostream &os, const Line &line,
-                             std::shared_ptr<common::Source> source) {
-  os << line.lineNumber << " | ";
-  os << source->content.substr(line.start(), line.length());
-  os << "\n";
-}
 
-template <typename S> struct SpanWrite {
-  static_assert(is_derived_from_span_v<S>, "S must be derived from Span");
-  static void write(std::ostream &os, const S &span, const Cache<S> &cache) {
-    std::optional<const CacheEntry *> entry = cache.getEntry(span);
+void writeLine(std::ostream &os, const Line &line,
+               std::shared_ptr<common::Source> source);
 
-    if (!entry.has_value()) {
-      return;
-    }
-
-    std::span<const Line> lines =
-        entry.value()->getLines(span.getRange());
-    if (lines.empty())
-      return;
-
-    const Line &line = lines.front();
-    std::size_t line_start = line.start();
-    std::size_t column = span.getStart() - line_start + 1;
-
-    os << "[" << span.source() << ":" << line.lineNumber << ":" << column
-       << "] ";
-
-    for (const auto &l : lines) {
-      write(os, l);
-    }
-  }
+struct SpanWrite {
+  static void write(std::ostream &os, const Span &span, const Cache &cache);
 };
+
 } // namespace sable::report

--- a/sc/main.cc
+++ b/sc/main.cc
@@ -18,24 +18,20 @@ int main() {
   sable::common::Manager manager;
   auto source = manager.addContent(SOURCE, "main.sable");
 
-  sable::report::Cache<sable::report::FileLocSpan> cache(manager);
+  sable::report::Cache cache(manager);
 
   Lexer lexer(source);
-  sable::report::StreamWriter<sable::report::FileLocSpan> writer(std::cout,
-                                                                 cache);
+  sable::report::StreamWriter writer(std::cout, cache);
 
   Token token;
   do {
     token = lexer.next();
     if (token.type == Token::Type::Unknown) {
-      sable::report::Diagnostic<sable::report::FileLocSpan> diag(
-          sable::report::Severity::Error);
+      sable::report::Diagnostic diag(sable::report::Severity::Error);
       diag.withMessage(std::string("Unknown token encountered: ") +
                        std::string(token.lexeme));
-      sable::report::FileLocSpan span(source->filename, token.location.range);
-      auto label =
-          sable::report::Label<sable::report::FileLocSpan>(span).withMessage(
-              "Invalid token found.");
+      sable::report::Span span(source->filename, token.location.range);
+      auto label = sable::report::Label(span).withMessage("Invalid token found.");
       diag.withCode(span).withLabel(label);
       writer.report(diag);
     }

--- a/sc/main.cc
+++ b/sc/main.cc
@@ -19,6 +19,7 @@ int main() {
   auto source = manager.addContent(SOURCE, "main.sable");
 
   sable::report::Cache cache(manager);
+  cache.addEntry(source);
 
   Lexer lexer(source);
   sable::report::StreamWriter writer(std::cout, cache);


### PR DESCRIPTION
## Summary
- remove generic span abstraction and use a simple `Span` type backed by `std::string_view`
- refactor report classes (`Cache`, `Diagnostic`, `Engine`, `Label`, `Write`) to drop templates
- split implementations into `.cc` files
- update CMake sources accordingly
- adjust sample `sc` application

## Testing
- `cmake ..`
- `cmake --build . -j4`


------
https://chatgpt.com/codex/tasks/task_e_685547c1d8888333ad984b00204a0b22