### PR TITLE
Improve diagnostic output formatting

### DIFF
--- a/libsable/report/Cache.cc
+++ b/libsable/report/Cache.cc
@@ -73,9 +73,11 @@ void Cache::addEntry(std::shared_ptr<common::Source> source) {
   if (!source) {
     return;
   }
-  auto it = entries.find(source->filename);
+
+  std::string_view filename = source->filename;
+  auto it = entries.find(filename);
   if (it == entries.end()) {
-    entries.emplace(source->filename, CacheEntry(std::move(source)));
+    entries.emplace(filename, CacheEntry(source));
   }
 }
 

--- a/libsable/report/Write.cc
+++ b/libsable/report/Write.cc
@@ -1,30 +1,50 @@
 #include "report/Write.h"
 #include "report/Diagnostic.h"
 #include "report/Span.h"
+#include <algorithm>
 #include <cstddef>
+#include <string>
 
 namespace sable::report {
 
-void writeLine(std::ostream &os, const Span &span, const Line &line,
-               std::shared_ptr<common::Source> source) {
-  os << " " << line.lineNumber << " | ";
-  os << source->content.substr(line.start(), line.length());
-  os << "\n   | ";
+namespace {
+
+std::size_t digits(std::size_t num) {
+  std::size_t d = 1;
+  while (num >= 10) {
+    num /= 10;
+    ++d;
+  }
+  return d;
+}
+
+std::string underline(const Span &span, const Line &line) {
+  std::string result;
   std::size_t line_start = line.start();
   std::size_t line_end = line.end();
   std::size_t span_start = span.start();
   std::size_t span_end = span.end();
-  std::size_t span_length = span.length();
 
   for (std::size_t i = line_start; i < line_end; ++i) {
-    if (i >= span_start && i < span_end) {
-      os << ANSI_YELLOW << "~" << ANSI_RESET;
+    if (i == span_start) {
+      result += std::string(ANSI_YELLOW) + "^" + ANSI_RESET;
+    } else if (i > span_start && i < span_end) {
+      result += std::string(ANSI_YELLOW) + "~" + ANSI_RESET;
     } else {
-      os << " ";
+      result += ' ';
     }
   }
+  return result;
+}
 
-  os << "\n";
+} // namespace
+
+void writeLine(std::ostream &os, const Span &span, const Line &line,
+               std::size_t width,
+               std::shared_ptr<common::Source> source) {
+  os << ' ' << line.lineNumber << " | "
+     << source->content.substr(line.start(), line.length()) << '\n';
+  os << std::string(width + 2, ' ') << " | " << underline(span, line) << '\n';
 }
 
 void writeSpan(std::ostream &os, const Span &span, const Cache &cache) {
@@ -45,8 +65,9 @@ void writeSpan(std::ostream &os, const Span &span, const Cache &cache) {
   os << "[" << span.source() << ":" << line.lineNumber << ":" << column
      << "]\n";
 
+  std::size_t width = digits(lines.back().lineNumber);
   for (const auto &l : lines) {
-    writeLine(os, span, l, entry.value()->source);
+    writeLine(os, span, l, width, entry.value()->source);
   }
 }
 

--- a/libsable/report/Write.h
+++ b/libsable/report/Write.h
@@ -3,12 +3,14 @@
 #include "common/Manager.h"
 #include "report/Cache.h"
 #include "report/Span.h"
+#include <cstddef>
 #include <memory>
 #include <ostream>
 
 namespace sable::report {
 
-void writeLine(std::ostream &os, const Line &line,
+void writeLine(std::ostream &os, const Span &span, const Line &line,
+               std::size_t width,
                std::shared_ptr<common::Source> source);
 
 void writeSpan(std::ostream &os, const Span &span, const Cache &cache);

--- a/sc/main.cc
+++ b/sc/main.cc
@@ -27,6 +27,22 @@ int main() {
   Lexer lexer(source);
   sable::report::StreamWriter writer(std::cout, cache);
 
+  {
+    sable::report::Span span(source->filename,
+                             sable::common::Range<std::size_t>(0, 4));
+    sable::report::Diagnostic info(sable::report::Severity::Info);
+    info.withMessage("Demonstrating info diagnostic").withCode(span);
+    writer.report(info);
+  }
+
+  {
+    sable::report::Span span(source->filename,
+                             sable::common::Range<std::size_t>(13, 16));
+    sable::report::Diagnostic warn(sable::report::Severity::Warning);
+    warn.withMessage("This number looks suspicious").withCode(span);
+    writer.report(warn);
+  }
+
   Token token;
   do {
     token = lexer.next();


### PR DESCRIPTION
## Summary
- fix unordered_map insertion in `Cache::addEntry`
- allow specifying padding width for highlighted lines
- rewrite `writeLine` to build colored underlines
- show reporter usage with info and warning examples in `main`

## Testing
- `cmake .. -G Ninja`
- `ninja`
- `./bin/sc`

------
https://chatgpt.com/codex/tasks/task_e_68556c4f555c83338774256961953c59